### PR TITLE
Migrate fantasy tracking logic to MongoDB

### DIFF
--- a/commands/yahoo-fantasy.ts
+++ b/commands/yahoo-fantasy.ts
@@ -1,6 +1,6 @@
 import { ApplicationCommandOptionTypes, ApplicationCommandTypes, Bot, Embed, FileContent, Interaction, InteractionCallbackData, InteractionResponseTypes } from 'discordeno/mod.ts';
 import { createCommand } from './mod.ts';
-import { getAccessToken, fetchStandings, fetchScoreboard, listGamesInRedis } from "../helpers/yahoo-fantasy/mod.ts";
+import { getAccessToken, fetchStandings, fetchScoreboard, listGamesInRedis, listGames } from "../helpers/yahoo-fantasy/mod.ts";
 
 // @deno-types="https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts"
 import Fuse from 'https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.min.js'
@@ -95,7 +95,7 @@ export const handleGraphAutocomplete = async (bot: Bot, interaction: Interaction
     const searchGameOption: any = detailsOption ? detailsOption.options.find((option: any) => option.name === 'game') : null;
     const searchGame: string = searchGameOption ? searchGameOption.value : '';
 
-    const games = await listGamesInRedis();
+    const games = await listGames();
 
     const fuse = new Fuse(games, {
         keys: ['week', 'team1', 'team2', 'key']

--- a/deno.lock
+++ b/deno.lock
@@ -1346,5 +1346,110 @@
     "https://unpkg.com/@evan/wasm@0.0.93/target/ed25519/deno.js": "9728126890f17b71cee41afdab8a4bc362f6b9f409fe0a5c4f6ca9f3b510fd3a",
     "https://unpkg.com/@evan/wasm@0.0.93/target/zlib/deno.js": "e65131e1c1f45e64960f2699a0b868927ea5c9201c4b986a7cfc57b18be5cc09",
     "https://unpkg.com/@evan/wasm@0.0.94/target/zlib/deno.js": "e65131e1c1f45e64960f2699a0b868927ea5c9201c4b986a7cfc57b18be5cc09"
+  },
+  "npm": {
+    "specifiers": {
+      "fast-xml-parser": "fast-xml-parser@4.2.7",
+      "mongodb": "mongodb@5.7.0"
+    },
+    "packages": {
+      "@types/node@18.11.9": {
+        "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+        "dependencies": {}
+      },
+      "@types/webidl-conversions@7.0.0": {
+        "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+        "dependencies": {}
+      },
+      "@types/whatwg-url@8.2.2": {
+        "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+        "dependencies": {
+          "@types/node": "@types/node@18.11.9",
+          "@types/webidl-conversions": "@types/webidl-conversions@7.0.0"
+        }
+      },
+      "bson@5.4.0": {
+        "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+        "dependencies": {}
+      },
+      "fast-xml-parser@4.2.7": {
+        "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
+        "dependencies": {
+          "strnum": "strnum@1.0.5"
+        }
+      },
+      "ip@2.0.0": {
+        "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+        "dependencies": {}
+      },
+      "memory-pager@1.5.0": {
+        "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+        "dependencies": {}
+      },
+      "mongodb-connection-string-url@2.6.0": {
+        "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+        "dependencies": {
+          "@types/whatwg-url": "@types/whatwg-url@8.2.2",
+          "whatwg-url": "whatwg-url@11.0.0"
+        }
+      },
+      "mongodb@5.7.0": {
+        "integrity": "sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==",
+        "dependencies": {
+          "bson": "bson@5.4.0",
+          "mongodb-connection-string-url": "mongodb-connection-string-url@2.6.0",
+          "saslprep": "saslprep@1.0.3",
+          "socks": "socks@2.7.1"
+        }
+      },
+      "punycode@2.3.0": {
+        "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+        "dependencies": {}
+      },
+      "saslprep@1.0.3": {
+        "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+        "dependencies": {
+          "sparse-bitfield": "sparse-bitfield@3.0.3"
+        }
+      },
+      "smart-buffer@4.2.0": {
+        "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+        "dependencies": {}
+      },
+      "socks@2.7.1": {
+        "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+        "dependencies": {
+          "ip": "ip@2.0.0",
+          "smart-buffer": "smart-buffer@4.2.0"
+        }
+      },
+      "sparse-bitfield@3.0.3": {
+        "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+        "dependencies": {
+          "memory-pager": "memory-pager@1.5.0"
+        }
+      },
+      "strnum@1.0.5": {
+        "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+        "dependencies": {}
+      },
+      "tr46@3.0.0": {
+        "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+        "dependencies": {
+          "punycode": "punycode@2.3.0"
+        }
+      },
+      "webidl-conversions@7.0.0": {
+        "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+        "dependencies": {}
+      },
+      "whatwg-url@11.0.0": {
+        "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+        "dependencies": {
+          "tr46": "tr46@3.0.0",
+          "webidl-conversions": "webidl-conversions@7.0.0"
+        }
+      }
+    }
   }
 }

--- a/helpers/yahoo-fantasy/convertToMongo.ts
+++ b/helpers/yahoo-fantasy/convertToMongo.ts
@@ -73,10 +73,11 @@ for (const transaction of transactions) {
                         status: player.transaction_data.type,
                     },
                     $set: {
+                        parentTransactionKey: transaction.transaction_key,
                         gameId: Number(gameId),
                         name: player.name.full,
-                        playerId: player.player_id,
-                        position: player.position_type,
+                        playerId: player.player_key,
+                        position: player.position,
                         sourceType: player.transaction_data.source_type,
                         sourceTeam: player.transaction_data.source_team_name,
                         sourceTeamKey: player.transaction_data.source_team_key,

--- a/helpers/yahoo-fantasy/convertToMongo.ts
+++ b/helpers/yahoo-fantasy/convertToMongo.ts
@@ -1,0 +1,116 @@
+import { connect } from 'redis/mod.ts';
+import { getAccessToken, getTeams } from './mod.ts';
+import { MongoClient } from 'npm:mongodb';
+import config from "../../config.ts";
+
+const mongo = await MongoClient.connect(config.mongo.url);
+
+console.log('Connected to MongoDB')
+console.log('Importing data...')
+console.log('Importing NFL 2022...')
+
+await mongo
+    .db('tangledbot')
+    .collection('games')
+    .updateOne(
+        {
+            id: 414
+        },
+        {
+            $setOnInsert: {
+                id: 414,
+                sport: 'nfl',
+                year: '2022',
+            }
+        },
+        { upsert: true }
+    )
+
+await mongo
+    .db('tangledbot')
+    .collection('leagues')
+    .updateOne(
+        {
+            id: 1353821
+        },
+        {
+            $setOnInsert: {
+                id: 1353821,
+                sportId: 414,
+                key: '414.l.1353821',
+                name: 'Fireworks Football Fanatics',
+                url: "https://football.fantasysports.yahoo.com/2022/f1/1353821",
+                logo: "https://yahoofantasysports-res.cloudinary.com/image/upload/t_s192sq/fantasy-logos/bc4791dc2df5a54e1129c71f2a150f9f983796450d6d5d8070507ace0b3b6f50.jpg",
+            }
+        },
+        { upsert: true }
+    )
+
+const transactionData = await Deno.readTextFile('transactions.json').then(x => JSON.parse(x));
+
+const transactions = transactionData.fantasy_content.league.transactions.transaction;
+
+for (const transaction of transactions) {
+    if (!Array.isArray(transaction.players.player)) {
+        transaction.players.player = [transaction.players.player];
+    }
+
+    const [gameId] = transaction.transaction_key.split('.');
+
+    await mongo
+        .db('tangledbot')
+        .collection('transactions')
+        .updateOne(
+            {
+                transactionKey: transaction.transaction_key,
+            },
+            {
+                $setOnInsert: {
+                    transactionKey: transaction.transaction_key,
+                    leagueId: 1353821,
+                    type: transaction.type,
+                    timestamp: new Date(transaction.timestamp * 1000),
+                    status: transaction.status,
+                },
+                $set: {
+                    gameId: Number(gameId),
+                    players: transaction.players.player,
+                }
+            },
+            { upsert: true }
+        )
+}
+
+console.log('Getting Teams...');
+
+const accessToken = await getAccessToken();
+const teams = await getTeams(accessToken)
+    .then(x => x.fantasy_content.league.teams.team);
+
+for (const team of teams) {
+    await mongo
+        .db('tangledbot')
+        .collection('teams')
+        .updateOne(
+            {
+                teamKey: team.team_key,
+            },
+            {
+                $setOnInsert: {
+                    teamKey: team.team_key,
+                    leagueId: 1353821,
+                    sportId: 414,
+                    logo: team.team_logos.team_logo.url,
+                    manager: team.managers.manager.nickname,
+                    managerAvatar: team.managers.manager.image_url,
+                },
+                $set: {
+                    name: team.name,
+                },
+            },
+            { upsert: true }
+        )
+}
+
+console.log('Done!');
+Deno.exit(0);

--- a/helpers/yahoo-fantasy/exportScores.ts
+++ b/helpers/yahoo-fantasy/exportScores.ts
@@ -1,0 +1,77 @@
+import { MongoClient } from 'npm:mongodb';
+import config from '../../config.ts';
+
+const mongo = await MongoClient.connect(config.mongo.url);
+const data = Deno.readTextFileSync('./scores.json');
+const json: any[] = JSON.parse(data);
+
+const teamKeyMap: {[x: string]: string} = {
+    "Georgetown Georges": "414.l.135821.t.4",
+    "LFY's Fascinating Yeeters": "414.l.135821.t.7",
+    "Seattle Businessmen": "414.l.135821.t.1",
+    "Flemington Furries": "414.l.135821.t.3",
+    "Winnipeg Stabfest": "414.l.135821.t.8",
+    "Slab Squatthrusts": "414.l.135821.t.6",
+    "2 Coopers 1 Kupp": "414.l.135821.t.2",
+    "Klepto's Clef Toes": "414.l.135821.t.5",
+    "Klepto's Clef Tua": "414.l.135821.t.5",
+    "2 Old Men and a Sun God": "414.l.135821.t.8",
+    "Ben Craven some Wins": "414.l.135821.t.1",
+    "Raincity Bitch Pigeons": "414.l.135821.t.1",
+    "THE COUGAR PIECE IS REAL": "414.l.135821.t.3",
+    "Sicklerville Sickos": "414.l.135821.t.3",
+    "Post Mahomes": "414.l.135821.t.2",
+    "Bad Luck Brady and the Bunch": "414.l.135821.t.8",
+    "Second Coming of a Sun God": "414.l.135821.t.8",
+    "Thick Thighs Save Lives": "414.l.135821.t.8",
+    "Absecon Axolotls": "414.l.135821.t.3",
+}
+
+for (const row of json) {
+    let matchupKey = `414.l.135821.mu.${row.week}`;
+    const week = row.week;
+
+    delete row.week;
+
+    const team1 = Object.keys(row)[0]
+    const team2 = Object.keys(row)[1]
+
+    const team1Id = teamKeyMap[team1];
+    const team2Id = teamKeyMap[team2];
+
+    const [,,,, team1No] = team1Id.split('.')
+    const [,,,, team2No] = team2Id.split('.')
+
+    matchupKey += `.${team1No}.v.${team2No}`;
+
+    console.log(`Importing ${team1} vs ${team2} - Week ${week}`);
+    
+    await mongo
+        .db('tangledbot')
+        .collection('matchups')
+        .updateOne(
+            {
+                matchupKey,
+            }, {
+                $setOnInsert: {
+                    matchupKey,
+                    gameId: 414,
+                    leagueId: 1353821,
+                    week,
+                },
+                $set: {
+                    team1Name: team1,
+                    team2Name: team2,
+                    team1Id,
+                    team2Id,
+                    team1ScoreTiming: row[team1],
+                    team2ScoreTiming: row[team2],
+                    team1Score: row[team1][row[team1].length - 1][1],
+                    team2ScoreMongoClient: row[team2][row[team2].length - 1][1],
+                }
+            }, 
+            { upsert: true }    
+        );
+}
+
+Deno.exit();

--- a/helpers/yahoo-fantasy/mod.ts
+++ b/helpers/yahoo-fantasy/mod.ts
@@ -389,27 +389,27 @@ export const collectTransactions = async () => {
     }
 };
 
-const accessToken = await getAccessToken();
-console.log(accessToken);
+// const accessToken = await getAccessToken();
+// console.log(accessToken);
 
-const {transactions} = await getTransactions(accessToken, '1353821', '414'); 
+// const {transactions} = await getTransactions(accessToken, '1353821', '414'); 
 
-// console.log(transactions);
+// // console.log(transactions);
 
-for (let transaction of transactions) {
-    console.log(transaction)
+// for (let transaction of transactions) {
+//     console.log(transaction)
 
-    if (Array.isArray(transaction.players.player)) {
-        for (let player of transaction.players.player) {
-            const playerDetais = await getPlayerDetails(accessToken, player.player_id, '414');
-            console.log(`Updated ${playerDetais.name.full}`)
-        }
-    } else {
-        const player = await getPlayerDetails(accessToken, transaction.players.player.player_id, '414');
-        console.log(`Updated ${player.name.full}`)
-    }
+//     if (Array.isArray(transaction.players.player)) {
+//         for (let player of transaction.players.player) {
+//             const playerDetais = await getPlayerDetails(accessToken, player.player_id, '414');
+//             console.log(`Updated ${playerDetais.name.full}`)
+//         }
+//     } else {
+//         const player = await getPlayerDetails(accessToken, transaction.players.player.player_id, '414');
+//         console.log(`Updated ${player.name.full}`)
+//     }
 
-    await (new Promise(resolve => setTimeout(resolve, 2000)));
-}
+//     await (new Promise(resolve => setTimeout(resolve, 2000)));
+// }
 
-Deno.exit(0);
+// Deno.exit(0);

--- a/helpers/yahoo-fantasy/mod.ts
+++ b/helpers/yahoo-fantasy/mod.ts
@@ -418,30 +418,3 @@ export const collectTransactions = async () => {
     }
 
 };
-
-const accessToken = await getAccessToken();
-console.log(accessToken);
-
-// const {transactions} = await getTransactions(accessToken, '1353821', '414'); 
-
-// // console.log(transactions);
-
-// for (let transaction of transactions) {
-//     console.log(transaction)
-
-//     if (Array.isArray(transaction.players.player)) {
-//         for (let player of transaction.players.player) {
-//             const playerDetais = await getPlayerDetails(accessToken, player.player_id, '414');
-//             console.log(`Updated ${playerDetais.name.full}`)
-//         }
-//     } else {
-//         const player = await getPlayerDetails(accessToken, transaction.players.player.player_id, '414');
-//         console.log(`Updated ${player.name.full}`)
-//     }
-
-//     await (new Promise(resolve => setTimeout(resolve, 2000)));
-// }
-
-await fetchScoreboard(accessToken, '1353821', '414');
-
-Deno.exit(0);

--- a/helpers/yahoo-fantasy/mod.ts
+++ b/helpers/yahoo-fantasy/mod.ts
@@ -241,7 +241,7 @@ export const getTransactions = async (accessToken: string, leagueId: string = '1
     };
 }
 
-export const getTeams = async (accessToken: string, leagueId: string = '1353821', gameId = 'nfl') => {
+export const getTeams = async (accessToken: string, leagueId = '1353821', gameId = 'nfl') => {
     const tradesRequest = await fetch(`https://fantasysports.yahooapis.com/fantasy/v2/league/${gameId}.l.${leagueId}/teams`, {
         headers: {
             'Authorization': `Bearer ${accessToken}`
@@ -256,7 +256,7 @@ export const getTeams = async (accessToken: string, leagueId: string = '1353821'
     return json;
 }
 
-export const getPlayerDetails = async (accessToken: string, playerId: string = '1353821', gameId = 'nfl') => {
+export const getPlayerDetails = async (accessToken: string, playerId = '1353821', gameId = 'nfl') => {
     const mongo = await MongoClient.connect(config.mongo.url);
     
     // check if player exists
@@ -307,68 +307,72 @@ export const getPlayerDetails = async (accessToken: string, playerId: string = '
 export const collectTransactions = async () => {
     const accessToken = await getAccessToken();
     const {league, transactions} = await getTransactions(accessToken, '1353821', '414');
-    const redis = await connect({
-        hostname: config.redis.hostname,
-    });
+    const mongo = await MongoClient.connect(config.mongo.url);
 
     for (const transaction of transactions) {
-        const {id, type, status, timestamp, players} = transaction;
-        const key = `transaction-${league.name}-${id}`;
-
-        const currentData = await redis.get(key);
-        if (currentData) {
+        const dataExists = await mongo
+            .db('tangledbot')
+            .collection('transactions')
+            .findOne({
+                parentTransactionKey: transaction.transaction_key,
+            });
+    
+        if (dataExists) {
             continue;
         }
 
-        const data = {
-            type,
-            status,
-            timestamp,
-            players
+        if (!Array.isArray(transaction.players)) {
+            transaction.players = [transaction.players];
         }
 
-        // await redis.set(key, JSON.stringify(data));
+        for (const [index, player] of transaction.players.entries()) {
+            await mongo
+                .db('tangledbot')
+                .collection('transactions')
+                .insertOne({
+                    transactionKey: `${transaction.transaction_key}.${index}`,
+                    leagueId: 1353821,
+                    type: transaction.type,
+                    timestamp: new Date(transaction.timestamp * 1000),
+                    status: player.transaction_data.type,
+                    parentTransactionKey: transaction.transaction_key,
+                    gameId: 'nfl',
+                    name: player.name.full,
+                    playerId: player.player_key,
+                    position: player.position,
+                    sourceType: player.transaction_data.source_type,
+                    sourceTeam: player.transaction_data.source_team_name,
+                    sourceTeamKey: player.transaction_data.source_team_key,
+                    destinationType: player.transaction_data.destination_type,
+                    destinationTeam: player.transaction_data.destination_team_name,
+                    destinationTeamKey: player.transaction_data.destination_team_key,
+                });
+        }
 
         const embed = {
             title: 'New Transaction',
-            description: players.map(p => {
+            description: transaction.players.map((p: any) => {
                 const {name, team, position, transaction_data} = p;
-                let type, source_type, destination_type, source, destination;
-                if (Array.isArray(transaction_data)) {
-                    type = transaction_data[0].type;
-                    source_type = transaction_data[0].source_type;
-                    destination_type = transaction_data[0].destination_type;
-                    if (source_type === 'team') {
-                        source = transaction_data[0].source_team_name;
-                    } else {
-                        source = transaction_data[0].source_type;
-                    }
-                    if (destination_type === 'team') {
-                        destination = transaction_data[0].destination_team_name;
-                    } else {
-                        destination = transaction_data[0].destination_type;
-                    }
+                let source, destination;
+                const type = transaction_data.type;
+                const source_type = transaction_data.source_type;
+                const destination_type = transaction_data.destination_type;
+                if (source_type === 'team') {
+                    source = transaction_data.source_team_name;
                 } else {
-                    type = transaction_data.type;
-                    source_type = transaction_data.source_type;
-                    destination_type = transaction_data.destination_type;
-                    if (source_type === 'team') {
-                        source = transaction_data.source_team_name;
-                    } else {
-                        source = transaction_data.source_type;
-                    }
-                    if (destination_type === 'team') {
-                        destination = transaction_data.destination_team_name;
-                    } else {
-                        destination = transaction_data.destination_type;
-                    }
+                    source = transaction_data.source_type;
+                }
+                if (destination_type === 'team') {
+                    destination = transaction_data.destination_team_name;
+                } else {
+                    destination = transaction_data.destination_type;
                 }
 
                 const typeEmoji = type === 'add' ? '🔺' : type === 'drop' ? '🔻' : '🔄';
 
                 return `${name} (${team} - ${position}) ${typeEmoji} ${source} -> ${destination}`;
             }).join('\n'),
-            timestamp: timestamp.toISOString(),
+            timestamp: new Date(transaction.timestamp * 1000).toISOString(),
         }
 
         console.log(embed);
@@ -379,13 +383,13 @@ export const collectTransactions = async () => {
             embeds: [embed]
         }
 
-        // await fetch(config.yahoo.discordWebhook, {
-        //     method: 'POST',
-        //     headers: {
-        //         'Content-Type': 'application/json'
-        //     },
-        //     body: JSON.stringify(webhookData)
-        // }).catch(err => console.error(err));
+        await fetch(config.yahoo.discordWebhook, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(webhookData)
+        }).catch(err => console.error(err));
     }
 };
 

--- a/helpers/yahoo-fantasy/mod.ts
+++ b/helpers/yahoo-fantasy/mod.ts
@@ -14,6 +14,7 @@ interface ParsedStandings {
 
 interface ScoreboardTeam {
     name: string,
+    teamKey: string,
     actualPoints: number,
     projectedPoints: number,
     winProbability: number
@@ -22,7 +23,6 @@ interface ScoreboardTeam {
 interface ParsedScoreboard {
     team1: ScoreboardTeam,
     team2: ScoreboardTeam,
-    key: string
 }
 
 export const getAccessToken = async () => {
@@ -121,7 +121,7 @@ export const fetchScoreboard = async (accessToken: string, leagueId: string = '1
 
     const league = json.fantasy_content.league;
     const matchups = json.fantasy_content.league.scoreboard.matchups.matchup;
-    let weekNumber: string = '';
+    let weekNumber = 0;
 
     for (const matchup of matchups) {
         weekNumber = matchup.week;
@@ -130,6 +130,7 @@ export const fetchScoreboard = async (accessToken: string, leagueId: string = '1
 
         const team1 = {
             name: matchupTeams[0].name,
+            teamKey: matchupTeams[0].team_key,
             actualPoints: matchupTeams[0].team_points.total,
             projectedPoints: matchupTeams[0].team_projected_points.total,
             winProbability: matchupTeams[0].win_probability
@@ -137,15 +138,14 @@ export const fetchScoreboard = async (accessToken: string, leagueId: string = '1
 
         const team2 = {
             name: matchupTeams[1].name,
+            teamKey: matchupTeams[1].team_key,
             actualPoints: matchupTeams[1].team_points.total,
             projectedPoints: matchupTeams[1].team_projected_points.total,
             winProbability: matchupTeams[1].win_probability
         }
 
-        const key = `week${weekNumber}-${team1.name}-vs-${team2.name}-points`;
-
         parsedScoreboard.push({
-            team1, team2, key
+            team1, team2
         });
     }
 
@@ -297,7 +297,7 @@ export const getPlayerDetails = async (accessToken: string, playerId = '1353821'
 
 export const collectTransactions = async () => {
     const accessToken = await getAccessToken();
-    const {league, transactions} = await getTransactions(accessToken, '1353821', '414');
+    const {league, transactions} = await getTransactions(accessToken, '1353821');
     const mongo = await MongoClient.connect(config.mongo.url);
 
     const embedsToSend: any[] = [];
@@ -420,6 +420,6 @@ console.log(accessToken);
 //     await (new Promise(resolve => setTimeout(resolve, 2000)));
 // }
 
-await fetchScoreboard(accessToken);
+// await fetchScoreboard(accessToken);
 
-Deno.exit(0);
+// Deno.exit(0);


### PR DESCRIPTION
- Start migration to mongodb from redis
- Flatten transactions
- remove script import calls
- Score import logic
- Add parent transactions
- Update transaction posting logic to check mongodb
- Update standings to use converted xml
- Update scoreboard logic to use parsed XML
- Publish embeds in batches of 10
- Remove redis key from scoreboard object
- Update score history to use MongoDB
- Update score fetch to use mongodb
- Remove debug logging
